### PR TITLE
Added new parameter: standingsType

### DIFF
--- a/docs/api/LEAGUE.md
+++ b/docs/api/LEAGUE.md
@@ -68,8 +68,13 @@
 
   * `standingsType`
     * Possible Values:
+      * regularSeason: `Regular Season Standings`
+      * wildCard: `Wild card standings`
+      * divisionLeaders: `Division Leader standings`
+      * wildCardWithLeaders: `Wild card standings with Division Leaders`
+      * preseason: `Preseason Standings`
+      * postseason: `Postseason Standings`
       * byDivision: `Standings by Division`
       * byConference: `Standings by Conference`
       * byLeague: `Standings by League`
-      * wildCardWithLeaders: `Wild card standings with Division Leaders`
         * Note: defaults to regularSeason

--- a/docs/api/LEAGUE.md
+++ b/docs/api/LEAGUE.md
@@ -32,7 +32,7 @@
 
 * `standings`
   * Parameters:
-    * NONE
+    * `standingsType`
 
 ### Parameter Reference
 
@@ -65,3 +65,11 @@
     * Possible Values:
       * Season format: `yyyyyyyy`
         * Example: `20172018`
+
+  * `standingsType`
+    * Possible Values:
+      * byDivision: `Standings by Division`
+      * byConference: `Standings by Conference`
+      * byLeague: `Standings by League`
+      * wildCardWithLeaders: `Wild card standings with Division Leaders`
+        * Note: defaults to regularSeason

--- a/src/api/league/constants/defaults.js
+++ b/src/api/league/constants/defaults.js
@@ -48,7 +48,8 @@ export const STANDINGS = {
     'standings.conference'
   ],
   method: 'standings',
-  endpoint: '/standings'
+  parameter: 'standingsType',
+  endpoint: '/standings/{{standingsType}}'
 }
 
 // TODO: standings on a given date provided ?date=10-10-2017


### PR DESCRIPTION
Be able to call any of the 9 `standingsTypes` in the API with the `standings` method.

- [x] Tested with the following code
```js
nhl.league.standings({ standingsType: 'byDivision' }).then(data => {
	const division = data
	console.log(division)
})
```

https://statsapi.web.nhl.com/api/v1/standingsTypes
```json
[ {
  "name" : "regularSeason",
  "description" : "Regular Season Standings"
}, {
  "name" : "wildCard",
  "description" : "Wild card standings"
}, {
  "name" : "divisionLeaders",
  "description" : "Division Leader standings"
}, {
  "name" : "wildCardWithLeaders",
  "description" : "Wild card standings with Division Leaders"
}, {
  "name" : "preseason",
  "description" : "Preseason Standings"
}, {
  "name" : "postseason",
  "description" : "Postseason Standings"
}, {
  "name" : "byDivision",
  "description" : "Standings by Division"
}, {
  "name" : "byConference",
  "description" : "Standings by Conference"
}, {
  "name" : "byLeague",
  "description" : "Standings by League"
} ]
```