### PR TITLE
Added gameType and more modifiers

### DIFF
--- a/docs/api/GAMES.md
+++ b/docs/api/GAMES.md
@@ -16,10 +16,10 @@
 
 * `games`
   * Parameters:
-    * `teamID`
     * `date`
     * `startDate`
     * `endDate`
+    * `gameType`
 
 ### Parameter Reference
 
@@ -34,3 +34,10 @@
   * `startDate`
     * Possible Values:
       * Date format: `yyyy-mm-dd`
+
+  * `gameType`
+    * Possible Values:
+      * Preseason: `PR`
+      * Regular season: `R`
+      * Postseason: `P`
+        * Note: defaults to current season

--- a/src/api/games/constants/defaults.js
+++ b/src/api/games/constants/defaults.js
@@ -33,5 +33,5 @@ export const GAMES = {
     'schedule.teams',
     'schedule.ticket'
   ],
-  endpoint: '/schedule?teamId={{teamID}}&date={{date}}&startDate={{startDate}}&endDate={{endDate}}'
+  endpoint: '/schedule?date={{date}}&startDate={{startDate}}&endDate={{endDate}}&gameType={{gameType}}'
 }

--- a/src/api/games/constants/defaults.js
+++ b/src/api/games/constants/defaults.js
@@ -27,7 +27,11 @@ export const GAME = {
 export const GAMES = {
   method: 'games',
   expand: [
-    'schedule.linescore'
+    'schedule.broadcasts',
+    'schedule.game.content.media.epg',
+    'schedule.linescore',
+    'schedule.teams',
+    'schedule.ticket'
   ],
   endpoint: '/schedule?teamId={{teamID}}&date={{date}}&startDate={{startDate}}&endDate={{endDate}}'
 }


### PR DESCRIPTION
- Be able to call `gameType` in the schedule API with additional modifiers.
- Be able to call all games without filtering by one team with `teamId`.

- [x] Tested with the following code
```js
nhl.games.games({ date: '2019-05-04', gameType: 'P' }).then(data => {
	const playoffs = data
	console.log(playoffs)
})
```